### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/ref/tricontour_vs_griddata.py
+++ b/ref/tricontour_vs_griddata.py
@@ -30,8 +30,8 @@ plt.colorbar() # draw colorbar
 plt.plot(x, y, 'ko', ms=3)
 plt.xlim(-2,2)
 plt.ylim(-2,2)
-plt.title('griddata and contour (%d points, %d grid points)' % (npts, ngridx*ngridy))
-print ('griddata and contour seconds: %f' % (time.clock() - start))
+plt.title('griddata and contour ({0:d} points, {1:d} grid points)'.format(npts, ngridx*ngridy))
+print ('griddata and contour seconds: {0:f}'.format((time.clock() - start)))
 
 # tricontour.
 start = time.clock()
@@ -44,7 +44,7 @@ plt.colorbar()
 plt.plot(x, y, 'ko', ms=3)
 plt.xlim(-2,2)
 plt.ylim(-2,2)
-plt.title('tricontour (%d points)' % npts)
-print ('tricontour seconds: %f' % (time.clock() - start))
+plt.title('tricontour ({0:d} points)'.format(npts))
+print ('tricontour seconds: {0:f}'.format((time.clock() - start)))
 
 plt.show()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vincentdavis:Gradient_Delauney_heatmap?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vincentdavis:Gradient_Delauney_heatmap?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
