### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/Example_bulk_geocode.py
+++ b/Example_bulk_geocode.py
@@ -44,7 +44,7 @@ for row in data:
     if rowcount in readrows:
         results = geocode.jeffco(row['SCH'])
         # this will result in lost rows
-        if results not in latlon and results != None: # make sure there are no duplicats
+        if results not in latlon and results is not None: # make sure there are no duplicats
             if len(latlon) % 100 == 0:
                 print('RowCount', rowcount, 'Val', row["TOTACTVAL"], "SCH",  row["SCH"], "len(latlon)", len(latlon))
             propvalue.append(int(row["TOTACTVAL"]))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vincentdavis:Gradient_Delauney_heatmap?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:vincentdavis:Gradient_Delauney_heatmap?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
